### PR TITLE
feat: set qt filter rules on our own

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,10 +63,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
+name = "bytemuck"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965ab7eb5f8f97d2a083c799f3a1b994fc397b2fe2da5d1da1626ce15a39f2b1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "c2-logs"
 version = "0.1.3"
 dependencies = [
  "anyhow",
+ "bytemuck",
  "clap",
  "colored",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["command-line-utilities"]
 
 [dependencies]
 anyhow = "1.0.75"
+bytemuck = { version = "1.14.0", features = ["derive"] }
 clap = { version = "4.4.4", features = ["derive"] }
 colored = "2.0.4"
 ctrlc = "3.4.1"
@@ -24,7 +25,10 @@ windows = { version = "0.51.1", features = [
     "Win32_System_Threading",
     "Win32_System_Console",
     "Win32_System_Diagnostics_Debug",
-    "Win32_System_WindowsProgramming"
+    "Win32_System_WindowsProgramming",
+    "Win32_System_LibraryLoader",
+    "Win32_System_Memory",
+    "Win32_Security",
 ] }
 
 [profile.release]
@@ -36,4 +40,3 @@ lto = true
 inherits = "release"
 debug = true
 split-debuginfo = "packed"
-

--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 # c2-logs
 
-Capture, filter and analyze logs from [Chatterino](https://chatterino.com) without restarting the application on Windows. You can download a prebuilt application from the [releases tab](https://github.com/Nerixyz/c2-logs/releases). This program uses [Windows' Debugger API](https://learn.microsoft.com/en-us/windows/win32/api/debugapi/) to capture logs from Chatterino.
+Capture, filter and analyze logs from [Chatterino](https://chatterino.com) without restarting the application on Windows. You can download a prebuilt application from the [releases tab](https://github.com/Nerixyz/c2-logs/releases). This program uses [Windows' Debugger API](https://learn.microsoft.com/en-us/windows/win32/api/debugapi/) to capture logs from Chatterino and calls [`QLoggingCategory::setFilterRules`](https://doc.qt.io/qt-6/qloggingcategory.html#setFilterRules).
 
 ## Usage
 
 1. Open Chatterino regularly
-2. Run `c2-logs` (or `./c2-logs.exe`)
-3. In Chatterino, run `/c2-set-logging-rules chatterino.*.debug=true` (or `/c2-set-logging-rules *.debug=true`) to enable debug logging.
+2. Run `c2-logs -r chatterino.*.debug=true` (if you don't have it in your `PATH`, run it using `.\c2-logs.exe`)
 
 You can filter the logs by providing arguments. The default mode is `exclude`, meaning any category you provide will be excluded.
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+unstable_features = true
+imports_granularity = "Crate"

--- a/src/managed_types.rs
+++ b/src/managed_types.rs
@@ -15,6 +15,14 @@ impl ManagedHandle {
     }
 }
 
+impl std::ops::Deref for ManagedHandle {
+    type Target = HANDLE;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 impl Drop for ManagedHandle {
     fn drop(&mut self) {
         unsafe {

--- a/src/qt.rs
+++ b/src/qt.rs
@@ -1,0 +1,210 @@
+use std::{
+    ffi::{self, CStr},
+    mem,
+};
+
+use anyhow::{anyhow, Context};
+use windows::{
+    core::{s, PCSTR},
+    Win32::{
+        Foundation::FreeLibrary,
+        System::{
+            Diagnostics::Debug::WriteProcessMemory,
+            LibraryLoader::{GetProcAddress, LoadLibraryA},
+            Memory::{VirtualAllocEx, MEM_COMMIT, PAGE_READWRITE},
+            Threading::{
+                CreateRemoteThread, OpenProcess, WaitForSingleObject, INFINITE,
+                PROCESS_CREATE_THREAD, PROCESS_VM_OPERATION, PROCESS_VM_WRITE,
+            },
+        },
+    },
+};
+
+use crate::managed_types::ManagedHandle;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QtVersion {
+    Qt5,
+    Qt6,
+}
+
+pub fn set_logging_rules(
+    pid: u32,
+    version: QtVersion,
+    core_path: &CStr,
+    rules: &str,
+) -> anyhow::Result<()> {
+    unsafe {
+        let qt_core =
+            LoadLibraryA(PCSTR(core_path.as_ptr() as *const u8)).context("LoadLibraryA")?;
+        let addr = GetProcAddress(
+            qt_core,
+            s!("?setFilterRules@QLoggingCategory@@SAXAEBVQString@@@Z"),
+        )
+        .ok_or_else(|| anyhow!("Failed to find QLoggingCategory::setFilterRules"))?;
+
+        let process = OpenProcess(
+            PROCESS_CREATE_THREAD | PROCESS_VM_WRITE | PROCESS_VM_OPERATION,
+            false,
+            pid,
+        )
+        .context("OpenProcess")?;
+        let process = ManagedHandle::new(process);
+
+        let allocation_size = version.allocation_size(rules);
+        let allocation =
+            VirtualAllocEx(*process, None, allocation_size, MEM_COMMIT, PAGE_READWRITE);
+        if allocation.is_null() {
+            return Err(anyhow!("Failed to allocate memory in process"));
+        }
+
+        let (data, start_addr) = version.make_qstring(allocation, rules);
+        if data.len() > allocation_size {
+            return Err(anyhow!("QString was larger than expected"));
+        }
+
+        WriteProcessMemory(
+            *process,
+            allocation,
+            data.as_ptr() as *mut ffi::c_void,
+            data.len(),
+            None,
+        )
+        .context("WriteProcessMemory")?;
+        let thread = CreateRemoteThread(
+            *process,
+            None,
+            0,
+            Some(std::mem::transmute(addr)),
+            Some(start_addr),
+            0,
+            None,
+        )
+        .context("CreateRemoteThread")?;
+
+        WaitForSingleObject(thread, INFINITE);
+
+        FreeLibrary(qt_core).ok();
+
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, bytemuck::NoUninit)]
+#[repr(C)]
+struct Qt5String {
+    d: usize,
+    data: Qt5TypedArrayData,
+}
+
+#[derive(Clone, Copy, bytemuck::NoUninit)]
+#[repr(C)]
+struct Qt5TypedArrayData {
+    r: ffi::c_int,
+    size: ffi::c_int,
+    flags: ffi::c_uint,
+    #[cfg(target_pointer_width = "64")]
+    _unused: ffi::c_uint,
+    offset: usize,
+}
+
+#[derive(Clone, Copy, bytemuck::NoUninit)]
+#[repr(C)]
+struct Qt6ArrayData {
+    header: usize,
+    data: usize,
+    length: usize,
+}
+
+impl QtVersion {
+    pub const fn allocation_size(&self, content: &str) -> usize {
+        match *self {
+            QtVersion::Qt5 => {
+                mem::size_of::<Qt5String>() + content.len() * 2 + mem::size_of::<ffi::c_ushort>()
+            }
+            QtVersion::Qt6 => content.len() * 2 + mem::size_of::<Qt6ArrayData>(),
+        }
+    }
+
+    pub fn make_qstring(
+        &self,
+        start_addr: *mut ffi::c_void,
+        content: &str,
+    ) -> (Vec<u8>, *mut ffi::c_void) {
+        match *self {
+            QtVersion::Qt5 => Self::make_qt5string(start_addr, content),
+            QtVersion::Qt6 => Self::make_qt6string(start_addr, content),
+        }
+    }
+
+    fn make_qt5string(start_addr: *mut ffi::c_void, content: &str) -> (Vec<u8>, *mut ffi::c_void) {
+        let mut buf = Vec::with_capacity(Self::Qt5.allocation_size(content));
+        let n_codepoints = widestring::encode_utf16(content.chars()).count();
+
+        buf.extend_from_slice(bytemuck::bytes_of(&Qt5String {
+            d: unsafe { (start_addr as *mut usize).offset(1) as *mut _ as usize },
+            data: Qt5TypedArrayData {
+                r: -1,
+                size: n_codepoints as ffi::c_int,
+                flags: 0,
+                #[cfg(target_pointer_width = "64")]
+                _unused: 0,
+                offset: mem::size_of::<Qt5TypedArrayData>(),
+            },
+        }));
+
+        for codepoint in widestring::encode_utf16(content.chars()).map(u16::to_ne_bytes) {
+            buf.push(codepoint[0]);
+            buf.push(codepoint[1]);
+        }
+        // null termination isn't technically required
+        buf.push(0);
+        buf.push(0);
+
+        (buf, start_addr)
+    }
+
+    fn make_qt6string(start_addr: *mut ffi::c_void, content: &str) -> (Vec<u8>, *mut ffi::c_void) {
+        // QString { data: QStringPrivate = *QArrayData<char16_t> }
+        let mut buf = Vec::with_capacity(Self::Qt6.allocation_size(content));
+        for codepoint in widestring::encode_utf16(content.chars()).map(u16::to_ne_bytes) {
+            buf.push(codepoint[0]);
+            buf.push(codepoint[1]);
+        }
+        let offset = buf.len();
+
+        buf.extend_from_slice(bytemuck::bytes_of(&Qt6ArrayData {
+            header: 0,
+            data: start_addr as usize,
+            length: offset / 2,
+        }));
+
+        (buf, unsafe {
+            (start_addr as *mut u8).add(offset) as *mut ffi::c_void
+        })
+    }
+}
+
+#[cfg(all(test, target_pointer_width = "64", target_endian = "little"))]
+mod tests {
+    use super::*;
+    use std::ptr;
+
+    #[test]
+    fn qt6() {
+        let (buf, _ptr) = QtVersion::Qt6.make_qstring(ptr::null_mut(), "Hello");
+        assert_eq!(
+            buf,
+            b"H\0e\0l\0l\0o\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x05\0\0\0\0\0\0\0"
+        )
+    }
+
+    #[test]
+    fn qt5() {
+        let (buf, _ptr) = QtVersion::Qt5.make_qstring(ptr::null_mut(), "Hello");
+        assert_eq!(
+            buf,
+            b"\x08\0\0\0\0\0\0\0\xFF\xFF\xFF\xFF\x05\0\0\0\0\0\0\0\0\0\0\0\x18\0\0\0\0\0\0\0H\0e\0l\0l\0o\0\0\0"
+        )
+    }
+}


### PR DESCRIPTION
This adds the option to set filter rules on Chatterino on our own. This way, users don't have to use `/c2-set-logging-rules` anymore.